### PR TITLE
마지막 로그인이 1년이 되는 회원 스케줄링 회원삭제 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,6 @@ repositories {
 }
 
 dependencyManagement {
-	imports {
-		mavenBom 'org.springframework.session:spring-session-bom:2021.1.1'
-	}
 }
 
 dependencies {

--- a/src/main/java/com/octskyout/users/UsersApplication.java
+++ b/src/main/java/com/octskyout/users/UsersApplication.java
@@ -2,7 +2,9 @@ package com.octskyout.users;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class UsersApplication {
 

--- a/src/main/java/com/octskyout/users/config/AsyncConfig.java
+++ b/src/main/java/com/octskyout/users/config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package com.octskyout.users.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor threadPool = new ThreadPoolTaskExecutor();
+
+        threadPool.setCorePoolSize(2);
+        threadPool.setMaxPoolSize(2);
+        threadPool.setQueueCapacity(5);
+        threadPool.setAllowCoreThreadTimeOut(true);
+        threadPool.setPrestartAllCoreThreads(false);
+        threadPool.setThreadNamePrefix("SCHEDULE-THREAD");
+        threadPool.initialize();
+
+        return threadPool;
+    }
+}

--- a/src/main/java/com/octskyout/users/oauth/repository/OauthUserRepository.java
+++ b/src/main/java/com/octskyout/users/oauth/repository/OauthUserRepository.java
@@ -1,9 +1,18 @@
 package com.octskyout.users.oauth.repository;
 
 import com.octskyout.users.oauth.entity.OauthUser;
+import java.time.LocalDateTime;
 import java.util.Optional;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface OauthUserRepository extends CrudRepository<OauthUser, String> {
+public interface OauthUserRepository extends JpaRepository<OauthUser, String> {
     Optional<OauthUser> findOauthUserByUsername(String username);
+
+    @Query("SELECT O FROM OauthUser as O WHERE O.lastLoginDateTime < :oneYearAgoDateTime")
+    Page<OauthUser> findLastLoginAtOneYearsAgoUsers(@Param("oneYearAgoDateTime") LocalDateTime oneYearAgoDateTime,
+                                                    Pageable pageable);
 }

--- a/src/main/java/com/octskyout/users/oauth/schedule/AccountDeleteSchedule.java
+++ b/src/main/java/com/octskyout/users/oauth/schedule/AccountDeleteSchedule.java
@@ -1,0 +1,37 @@
+package com.octskyout.users.oauth.schedule;
+
+import com.octskyout.users.oauth.entity.OauthUser;
+import com.octskyout.users.oauth.repository.OauthUserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableAsync
+@RequiredArgsConstructor
+public class AccountDeleteSchedule {
+    private final OauthUserRepository oauthUserRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @Async
+    public void finalLoggedAfterOneYearAccountDelete() {
+        LocalDateTime oneYearsAgo = LocalDate.now()
+            .minusYears(1L)
+            .atTime(0, 0);
+
+        Long threadNumber = Thread.currentThread().getId();
+        Pageable pageable = PageRequest.of(threadNumber.intValue(),30);
+
+        Page<OauthUser> deleteTargets =
+            oauthUserRepository.findLastLoginAtOneYearsAgoUsers(oneYearsAgo, pageable);
+
+        oauthUserRepository.deleteAll(deleteTargets.getContent());
+    }
+}

--- a/src/main/java/com/octskyout/users/oauth/schedule/AccountDeleteSchedule.java
+++ b/src/main/java/com/octskyout/users/oauth/schedule/AccountDeleteSchedule.java
@@ -5,6 +5,7 @@ import com.octskyout.users.oauth.repository.OauthUserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 @Component
 @EnableAsync
 @RequiredArgsConstructor
+@Slf4j
 public class AccountDeleteSchedule {
     private final OauthUserRepository oauthUserRepository;
 
@@ -27,6 +29,7 @@ public class AccountDeleteSchedule {
             .atTime(0, 0);
 
         Long threadNumber = Thread.currentThread().getId();
+        log.debug("thread num : {}", threadNumber);
         Pageable pageable = PageRequest.of(threadNumber.intValue(),30);
 
         Page<OauthUser> deleteTargets =

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,8 +26,8 @@ spring:
   sql:
     init:
       mode: always
-      schema-locations: h2-test-ddl.sql
-      data-locations: h2-test-dml.sql
+      schema-locations: classpath:h2-test-ddl.sql
+      data-locations: classpath:h2-test-dml.sql
 
   h2:
     console:

--- a/src/main/resources/h2-test-dml.sql
+++ b/src/main/resources/h2-test-dml.sql
@@ -1,2 +1,5 @@
 insert into oauth_user (`email`,`username`,`github_id`)
     values ('admin@naver.com', 'admin', 123);
+
+insert into oauth_user (`email`,`username`,`github_id`, `last_login_date_time`)
+values ('admin@naver.com', 'admin', 123, '2021-01-01 00:00:00');

--- a/src/test/java/com/octskyout/users/oauth/repository/OauthUserRepositoryTest.java
+++ b/src/test/java/com/octskyout/users/oauth/repository/OauthUserRepositoryTest.java
@@ -4,11 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.octskyout.users.oauth.entity.OauthUser;
 import com.octskyout.users.oauth.github.dto.GithubUserDto;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @DataJpaTest
 class OauthUserRepositoryTest {
@@ -43,5 +47,42 @@ class OauthUserRepositoryTest {
     void username으로_사용자_탐색_실패() {
         Optional<OauthUser> user = oauthUserRepository.findOauthUserByUsername("empty");
         assertThat(user).isEmpty();
+    }
+
+    @Test
+    void 마지막_로그인이_1년전인_계정들을_찾는쿼리_성공() {
+        Pageable pageable = Pageable.ofSize(10);
+        LocalDateTime oneYearAgoLdt = LocalDateTime.now().minusYears(1L);
+        Page<OauthUser> oneYearsAgoLoggedUsers =
+            oauthUserRepository.findLastLoginAtOneYearsAgoUsers(oneYearAgoLdt, pageable);
+
+        assertThat(oneYearsAgoLoggedUsers.getTotalPages())
+            .isEqualTo(1);
+        assertThat(oneYearsAgoLoggedUsers.hasContent()).isTrue();
+    }
+
+    @Test
+    void 마지막_로그인이_1년전인_계정들의_2번페이지는_존재하지않으므로_실패() {
+        Pageable pageable = PageRequest.of(2, 10);
+
+        LocalDateTime oneYearAgoLdt = LocalDateTime.now().minusYears(1L);
+        Page<OauthUser> oneYearsAgoLoggedUsers =
+            oauthUserRepository.findLastLoginAtOneYearsAgoUsers(oneYearAgoLdt, pageable);
+
+        assertThat(oneYearsAgoLoggedUsers.getNumber())
+            .isEqualTo(2);
+        assertThat(oneYearsAgoLoggedUsers.hasContent()).isFalse();
+    }
+
+    @Test
+    void 마지막_로그인이_3년전인_계정은_없으므로_순열의_크기는_0이어야한다() {
+        Pageable pageable = Pageable.ofSize(10);
+        LocalDateTime threeYearsAgo = LocalDateTime.now().minusYears(3L);
+        Page<OauthUser> threeYearsAgoLoggedUsers =
+            oauthUserRepository.findLastLoginAtOneYearsAgoUsers(threeYearsAgo, pageable);
+
+        assertThat(threeYearsAgoLoggedUsers.getTotalPages())
+            .isEqualTo(0);
+        assertThat(threeYearsAgoLoggedUsers.hasContent()).isFalse();
     }
 }

--- a/src/test/java/com/octskyout/users/oauth/schedule/AccountCronRemote.java
+++ b/src/test/java/com/octskyout/users/oauth/schedule/AccountCronRemote.java
@@ -1,0 +1,56 @@
+package com.octskyout.users.oauth.schedule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.lang.reflect.Method;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.scheduling.support.SimpleTriggerContext;
+
+@Slf4j
+public class AccountCronRemote {
+    public void assertSchedule(String cronExpression, LocalDateTime initialTime,
+                                List<LocalDateTime> expectedLocalDateTimes) {
+        CronTrigger trigger = new CronTrigger(cronExpression);
+        Date startTime;
+        startTime = Timestamp.valueOf(initialTime);
+
+        SimpleTriggerContext context = new SimpleTriggerContext();
+        context.update(startTime, startTime, startTime);
+
+        expectedLocalDateTimes.forEach(expectTime -> {
+            Date nextExecutionTime = trigger.nextExecutionTime(context);
+            LocalDateTime actualTime =
+                new Timestamp(nextExecutionTime.getTime()).toLocalDateTime();
+
+            log.info("---------------------------------------");
+            log.info("스케쥴링 기대 작동시간 : {}", expectTime);
+            log.info("스케쥴링 실제 작동시간 : {}", actualTime);
+            log.info("---------------------------------------");
+            assertThat("executed on expected time", actualTime, is(expectTime));
+            context.update(nextExecutionTime, nextExecutionTime, nextExecutionTime);
+        });
+    }
+
+    public AccountCronRemoteInfo getCornExpressionFromMethod(Class<?> clazz, String methodName) {
+        Method scheduleMethod;
+        try {
+            scheduleMethod = clazz.getMethod(methodName);
+        } catch (NoSuchMethodException e) {
+            log.error("메서드가 존재하지않음.");
+            throw new RuntimeException(e);
+        }
+        Scheduled scheduleInfo = scheduleMethod.getAnnotation(Scheduled.class);
+        String cronExpression = scheduleInfo.cron();
+        return new AccountCronRemoteInfo(this, cronExpression);
+    }
+}
+
+record AccountCronRemoteInfo(AccountCronRemote remote, String cornPattern) {
+}

--- a/src/test/java/com/octskyout/users/oauth/schedule/AccountDeleteScheduleTest.java
+++ b/src/test/java/com/octskyout/users/oauth/schedule/AccountDeleteScheduleTest.java
@@ -7,26 +7,29 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
 
-import com.octskyout.users.config.AsyncConfig;
 import com.octskyout.users.oauth.dummy.OauthUserDummy;
 import com.octskyout.users.oauth.entity.OauthUser;
 import com.octskyout.users.oauth.repository.OauthUserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.Executor;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@Import({AccountDeleteSchedule.class, AsyncConfig.class})
+@Import({AccountDeleteSchedule.class})
 @Order(1)
 class AccountDeleteScheduleTest {
     @Autowired
@@ -35,11 +38,20 @@ class AccountDeleteScheduleTest {
     @MockBean
     OauthUserRepository oauthUserRepository;
 
+
+    @Configuration
+    static class ContextConfiguration implements AsyncConfigurer {
+        @Override
+        public Executor getAsyncExecutor() {
+            return new SyncTaskExecutor();
+        }
+    }
+
     @Test
     void 회원삭제_스케줄링을_실행하는_로직은_실행되어야한다() {
         OauthUser user = OauthUserDummy.githubUserDummy().get();
         List<OauthUser> deleteUsers = List.of(user);
-        Pageable pageable = PageRequest.of(19, 30);
+        Pageable pageable = PageRequest.of(1, 30);
         Page<OauthUser> deleteTargetUsers = new PageImpl<>(deleteUsers, pageable, 1);
 
         given(oauthUserRepository.findLastLoginAtOneYearsAgoUsers(any(LocalDateTime.class), eq(pageable)))
@@ -61,7 +73,7 @@ class AccountDeleteScheduleTest {
 
     @Test
     void 회원삭제_스케줄링의_cron이_원하는_때에_실행되어야한다() {
-        LocalDateTime now = LocalDateTime.of(2023,01,01, 0, 0);
+        LocalDateTime now = LocalDateTime.of(2023,1,1, 0, 0);
         List<LocalDateTime> expectedLocalDateTimes = List.of(
             now.plusDays(1),
             now.plusDays(2),

--- a/src/test/java/com/octskyout/users/oauth/schedule/AccountDeleteScheduleTest.java
+++ b/src/test/java/com/octskyout/users/oauth/schedule/AccountDeleteScheduleTest.java
@@ -1,0 +1,76 @@
+package com.octskyout.users.oauth.schedule;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+
+import com.octskyout.users.config.AsyncConfig;
+import com.octskyout.users.oauth.dummy.OauthUserDummy;
+import com.octskyout.users.oauth.entity.OauthUser;
+import com.octskyout.users.oauth.repository.OauthUserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@Import({AccountDeleteSchedule.class, AsyncConfig.class})
+@Order(1)
+class AccountDeleteScheduleTest {
+    @Autowired
+    AccountDeleteSchedule schedule;
+
+    @MockBean
+    OauthUserRepository oauthUserRepository;
+
+    @Test
+    void 회원삭제_스케줄링을_실행하는_로직은_실행되어야한다() {
+        OauthUser user = OauthUserDummy.githubUserDummy().get();
+        List<OauthUser> deleteUsers = List.of(user);
+        Pageable pageable = PageRequest.of(19, 30);
+        Page<OauthUser> deleteTargetUsers = new PageImpl<>(deleteUsers, pageable, 1);
+
+        given(oauthUserRepository.findLastLoginAtOneYearsAgoUsers(any(LocalDateTime.class), eq(pageable)))
+            .willReturn(deleteTargetUsers);
+
+        willDoNothing()
+            .given(oauthUserRepository)
+            .deleteAll(deleteUsers);
+
+        schedule.finalLoggedAfterOneYearAccountDelete();
+
+        then(oauthUserRepository)
+            .should(times(1))
+            .findLastLoginAtOneYearsAgoUsers(any(LocalDateTime.class), any(Pageable.class));
+        then(oauthUserRepository)
+            .should(times(1))
+            .deleteAll(deleteUsers);
+    }
+
+    @Test
+    void 회원삭제_스케줄링의_cron이_원하는_때에_실행되어야한다() {
+        LocalDateTime now = LocalDateTime.of(2023,01,01, 0, 0);
+        List<LocalDateTime> expectedLocalDateTimes = List.of(
+            now.plusDays(1),
+            now.plusDays(2),
+            now.plusDays(3)
+        );
+        AccountCronRemoteInfo remoteInfo = new AccountCronRemote()
+            .getCornExpressionFromMethod(AccountDeleteSchedule.class, "finalLoggedAfterOneYearAccountDelete");
+
+        remoteInfo.remote()
+            .assertSchedule(remoteInfo.cornPattern(), now, expectedLocalDateTimes);
+    }
+}

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,1 +1,0 @@
-junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation


### PR DESCRIPTION
close #17 

1. 1년전 마지막 로그인한 회원들을 조회하는 쿼리 테스트
2. 마지막 로그인 회원 쿼리 기능 생성
3. dml 추가 및 application.yml의 ddl, dml classpath 구문 추가
4. 스케줄링 로직 테스트
5. 스케줄링 cron 테스트
6. 스케줄 기능 완성
7. 비동기 Async 설정 및 스케줄링 비동기 처리 추가